### PR TITLE
Let dispatch id comparison decide when to run route handlers or not rather than route path check

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -155,9 +155,6 @@ export default class Router {
   __dispatch(canonicalPath, replace) {
     this.__dispatchId++;
     this.__startTime = fns.getNow();
-    if (canonicalPath === this.__currentCanonicalPath) {
-      return
-    }
 
     let title = DocumentEnv.getTitle()
     let path = fns.extractPath(this.opts.base, canonicalPath)


### PR DESCRIPTION
Before this change, if a user clicked on the same route twice before the handlers finished running, the handlers would never finish running, and the ui would be stuck in a loading state.

@jordangarcia  can you review?