### PR TITLE
Use path instead of canonicalPath in state object

### DIFF
--- a/dist/Context.js
+++ b/dist/Context.js
@@ -53,7 +53,7 @@ var Context = (function () {
     key: 'getHistoryArgs',
     value: function getHistoryArgs() {
       var state = {
-        canonicalPath: this.canonicalPath
+        path: this.canonicalPath
       };
       var url = this.canonicalPath;
 

--- a/dist/Router.js
+++ b/dist/Router.js
@@ -233,9 +233,7 @@ var Router = (function () {
     key: '__onpopstate',
     value: function __onpopstate(e) {
       if (e.state) {
-        this.replace(e.state.canonicalPath);
-      } else {
-        this.go(this.__currentCanonicalPath);
+        this.replace(e.state.path);
       }
     }
   }]);

--- a/src/Context.js
+++ b/src/Context.js
@@ -27,7 +27,7 @@ export default class Context {
    */
   getHistoryArgs() {
     let state = {
-      canonicalPath: this.canonicalPath,
+      path: this.canonicalPath,
     }
     let url = this.canonicalPath
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -178,8 +178,6 @@ export default class Router {
   __onpopstate(e) {
     if (e.state) {
       this.replace(e.state.canonicalPath)
-    } else {
-      this.go(this.__currentCanonicalPath)
     }
   }
 }

--- a/src/Router.js
+++ b/src/Router.js
@@ -177,7 +177,7 @@ export default class Router {
 
   __onpopstate(e) {
     if (e.state) {
-      this.replace(e.state.canonicalPath)
+      this.replace(e.state.path)
     }
   }
 }


### PR DESCRIPTION
Also if state isn't available in popstate object, don't route to canonical path, this causes issues if path has come from a redirect - user can get stuck in a redirect loop when they click the browser back button

@jordangarcia 