### PR TITLE
Fix build script

### DIFF
--- a/dist/Context.js
+++ b/dist/Context.js
@@ -1,20 +1,20 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _fns = require('./fns');
 
 var _fns2 = _interopRequireDefault(_fns);
 
-var Context = (function () {
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Context = function () {
   /**
    * @param {Object} opts
    * @param {String} opts.path
@@ -23,13 +23,12 @@ var Context = (function () {
    * @param {Object} opts.params
    * @param {Number} opts.dispatchId
    */
-
   function Context(_ref) {
-    var path = _ref.path;
-    var canonicalPath = _ref.canonicalPath;
-    var title = _ref.title;
-    var params = _ref.params;
-    var dispatchId = _ref.dispatchId;
+    var path = _ref.path,
+        canonicalPath = _ref.canonicalPath,
+        title = _ref.title,
+        params = _ref.params,
+        dispatchId = _ref.dispatchId;
 
     _classCallCheck(this, Context);
 
@@ -40,14 +39,15 @@ var Context = (function () {
     this.dispatchId = dispatchId;
 
     // computeds
-    this.queryString = _fns2['default'].extractQueryString(canonicalPath);
-    this.queryParams = _fns2['default'].extractQueryParams(canonicalPath);
+    this.queryString = _fns2.default.extractQueryString(canonicalPath);
+    this.queryParams = _fns2.default.extractQueryParams(canonicalPath);
   }
 
   /**
    * Gets arguments that can be applied to history.pushState / history.replaceState
    * @return {String[]}
    */
+
 
   _createClass(Context, [{
     key: 'getHistoryArgs',
@@ -62,7 +62,7 @@ var Context = (function () {
   }]);
 
   return Context;
-})();
+}();
 
-exports['default'] = Context;
+exports.default = Context;
 module.exports = exports['default'];

--- a/dist/DocumentEnv.js
+++ b/dist/DocumentEnv.js
@@ -7,7 +7,7 @@ function getTitle() {
   return document.title;
 }
 
-exports["default"] = {
+exports.default = {
   getTitle: getTitle
 };
 module.exports = exports["default"];

--- a/dist/HistoryEnv.js
+++ b/dist/HistoryEnv.js
@@ -11,7 +11,7 @@ function replaceState() {
   return window.history.replaceState.apply(window.history, arguments);
 }
 
-exports["default"] = {
+exports.default = {
   replaceState: replaceState,
   pushState: pushState
 };

--- a/dist/Route.js
+++ b/dist/Route.js
@@ -1,20 +1,20 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var _pathToRegexp = require('path-to-regexp');
 
 var _pathToRegexp2 = _interopRequireDefault(_pathToRegexp);
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
 var Route = function Route(_ref) {
-  var match = _ref.match;
-  var handle = _ref.handle;
+  var match = _ref.match,
+      handle = _ref.handle;
 
   _classCallCheck(this, Route);
 
@@ -22,8 +22,8 @@ var Route = function Route(_ref) {
   this.handlers = handle;
   this.keys = [];
 
-  this.matchRegexp = (0, _pathToRegexp2['default'])(this.match, this.keys);
+  this.matchRegexp = (0, _pathToRegexp2.default)(this.match, this.keys);
 };
 
-exports['default'] = Route;
+exports.default = Route;
 module.exports = exports['default'];

--- a/dist/Router.js
+++ b/dist/Router.js
@@ -1,6 +1,12 @@
-/**
- * @module
- */
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }(); /**
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      * @module
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      */
 
 /**
  * Input to Client Decision Engine
@@ -15,18 +21,6 @@
  * @param {Context} ctx
  * @param {Function} nextFn
  */
-
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var _objectAssign = require('object-assign');
 
@@ -56,13 +50,17 @@ var _DocumentEnv = require('./DocumentEnv');
 
 var _DocumentEnv2 = _interopRequireDefault(_DocumentEnv);
 
-var Router = (function () {
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Router = function () {
   function Router(opts) {
     _classCallCheck(this, Router);
 
     this.opts = opts || {};
 
-    this.opts = (0, _objectAssign2['default'])({
+    this.opts = (0, _objectAssign2.default)({
       pushstate: true,
       base: ''
     }, opts);
@@ -71,7 +69,7 @@ var Router = (function () {
 
     this.onRouteComplete = this.opts.onRouteComplete;
 
-    _WindowEnv2['default'].addEventListener('popstate', this.__onpopstate.bind(this));
+    _WindowEnv2.default.addEventListener('popstate', this.__onpopstate.bind(this));
   }
 
   _createClass(Router, [{
@@ -104,6 +102,7 @@ var Router = (function () {
      *
      * @param {Route[]} routes
      */
+
   }, {
     key: 'registerRoutes',
     value: function registerRoutes(routes) {
@@ -113,13 +112,14 @@ var Router = (function () {
         throw new Error('Router#registerRoutes must be passed an array of Routes');
       }
       routes.forEach(function (route) {
-        _this.__routes.push(new _Route2['default'](route));
+        _this.__routes.push(new _Route2.default(route));
       });
     }
 
     /**
      * @param {String} path
      */
+
   }, {
     key: 'registerCatchallPath',
     value: function registerCatchallPath(path) {
@@ -129,6 +129,7 @@ var Router = (function () {
     /**
      * @param {String} canonicalPath
      */
+
   }, {
     key: 'go',
     value: function go(canonicalPath) {
@@ -138,6 +139,7 @@ var Router = (function () {
     /**
      * @param {String} canonicalPath
      */
+
   }, {
     key: 'replace',
     value: function replace(canonicalPath) {
@@ -147,18 +149,19 @@ var Router = (function () {
     key: 'reset',
     value: function reset() {
       this.setInitialState();
-      _WindowEnv2['default'].removeEventListener('popstate', this.__onpopstate);
+      _WindowEnv2.default.removeEventListener('popstate', this.__onpopstate);
     }
   }, {
     key: 'catchall',
     value: function catchall() {
-      _WindowEnv2['default'].navigate(this.__catchallPath);
+      _WindowEnv2.default.navigate(this.__catchallPath);
     }
 
     /**
      * @param {RouterHandler[]} handlers
      * @param {Context} ctx
      */
+
   }, {
     key: '__runHandlers',
     value: function __runHandlers(handlers, ctx, callback) {
@@ -190,40 +193,40 @@ var Router = (function () {
      * @param {String} canonicalPath
      * @param {Boolean} replace use replaceState instead of pushState
      */
+
   }, {
     key: '__dispatch',
     value: function __dispatch(canonicalPath) {
       var _this3 = this;
 
-      var mode = arguments.length <= 1 || arguments[1] === undefined ? 'push' : arguments[1];
+      var mode = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'push';
 
       this.__dispatchId++;
       if (mode !== 'replace') {
-        this.__startTime = _fns2['default'].getNow();
+        this.__startTime = _fns2.default.getNow();
       }
 
-      var title = _DocumentEnv2['default'].getTitle();
-      var path = _fns2['default'].extractPath(this.opts.base, canonicalPath);
+      var title = _DocumentEnv2.default.getTitle();
+      var path = _fns2.default.extractPath(this.opts.base, canonicalPath);
 
-      var _fns$matchRoute = _fns2['default'].matchRoute(this.__routes, path);
+      var _fns$matchRoute = _fns2.default.matchRoute(this.__routes, path),
+          params = _fns$matchRoute.params,
+          route = _fns$matchRoute.route;
 
-      var params = _fns$matchRoute.params;
-      var route = _fns$matchRoute.route;
-
-      var ctx = new _Context2['default']({ canonicalPath: canonicalPath, path: path, title: title, params: params, dispatchId: this.__dispatchId });
+      var ctx = new _Context2.default({ canonicalPath: canonicalPath, path: path, title: title, params: params, dispatchId: this.__dispatchId });
 
       if (route) {
         if (mode === 'replace') {
-          _HistoryEnv2['default'].replaceState.apply(null, ctx.getHistoryArgs());
+          _HistoryEnv2.default.replaceState.apply(null, ctx.getHistoryArgs());
         } else if (mode === 'push') {
-          _HistoryEnv2['default'].pushState.apply(null, ctx.getHistoryArgs());
+          _HistoryEnv2.default.pushState.apply(null, ctx.getHistoryArgs());
         }
 
         this.__currentCanonicalPath = canonicalPath;
 
         this.__runHandlers(route.handlers, ctx, function () {
           var startTime = _this3.__startTime;
-          var endTime = _fns2['default'].getNow();
+          var endTime = _fns2.default.getNow();
           var duration = endTime - startTime;
           var fromPath = _this3.__fromPath || 'PAGE LOAD';
           var toPath = canonicalPath;
@@ -254,7 +257,7 @@ var Router = (function () {
   }]);
 
   return Router;
-})();
+}();
 
-exports['default'] = Router;
+exports.default = Router;
 module.exports = exports['default'];

--- a/dist/WindowEnv.js
+++ b/dist/WindowEnv.js
@@ -18,7 +18,7 @@ function navigate(location) {
   window.location = location;
 }
 
-exports["default"] = {
+exports.default = {
   navigate: navigate,
   addEventListener: addEventListener,
   removeEventListener: removeEventListener

--- a/dist/fns.js
+++ b/dist/fns.js
@@ -1,12 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 /**
  * @param {String} path
  * @return {String}
  */
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
 function extractQueryString(path) {
   var i = path.indexOf('?');
   var isFound = i > -1;
@@ -101,7 +101,7 @@ function getNow() {
   return Date.now();
 }
 
-exports['default'] = {
+exports.default = {
   extractQueryString: extractQueryString,
   extractQueryParams: extractQueryParams,
   extractPath: extractPath,

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,14 +1,14 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 var _Router = require('./Router');
 
 var _Router2 = _interopRequireDefault(_Router);
 
-exports['default'] = _Router2['default'];
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = _Router2.default;
 module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "expect": "^1.20.2"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
+    "babel-cli": "^6.18.0",
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.18.0",
     "karma": "^1.3.0",
     "karma-babel-preprocessor": "^6.0.1",

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 rm -rf dist
-`npm bin`/babel src --out-dir dist
+`npm bin`/babel src --out-dir dist --presets=es2015 --plugins=add-module-exports


### PR DESCRIPTION
@jordangarcia I think we need this in order to fix the build script. After updating to babel 6, the babel package doesn't do anything anymore, and all the CLI commands were moved to babel-cli.

I added a plugin (babel-plugin-add-module-exports) to keep the output in dist/ as close as possible to how it was before. It's still slightly different, but it works in basic testing in the optimizely app.