### PR TITLE
feat (Route Metadata): Pass route metadata to the onRouteComplete handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 npm-debug.log

--- a/src/Router.js
+++ b/src/Router.js
@@ -174,9 +174,9 @@ export default class Router {
       }
 
       this.__currentCanonicalPath = canonicalPath
+      const routeMetadata = route.metadata || {};
 
       if (this.onRouteStart && mode !== 'replace') {
-        const routeMetadata = route.metadata || {};
         this.onRouteStart({
           routeMetadata,
           fromPath: this.__fromPath || 'PAGE LOAD',
@@ -199,6 +199,7 @@ export default class Router {
             duration,
             startTime,
             endTime,
+            routeMetadata,
           });
         }
 

--- a/test/Router.spec.js
+++ b/test/Router.spec.js
@@ -260,6 +260,7 @@ describe('Router', () => {
       expect(args.fromPath).toBe('PAGE LOAD')
       expect(args.toPath).toBe('/foo')
       expect(args.duration).toBe(3)
+      expect(args.routeMetadata).toEqual({ bar: 'baz'})
 
       router.go('/bar/1/baz/2')
       sinon.assert.calledTwice(onRouteCompleteSpy)
@@ -268,6 +269,7 @@ describe('Router', () => {
       expect(args.fromPath).toBe('/foo')
       expect(args.toPath).toBe('/bar/1/baz/2')
       expect(args.duration).toBe(9)
+      expect(args.routeMetadata).toEqual({})
 
       fns.getNow.restore()
     })


### PR DESCRIPTION
We have a route property called `metadata` that is passed to the `onRouteStart` handler.

This PR simply updates it to be passed to the `onRouteComplete` handler.