### PR TITLE
add(method)[FE-896]: Add method for executing code without listening for popstate

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -48,6 +48,7 @@ export default class Router {
     this.__catchallPath = null;
     this.__dispatchId = 0;
     this.__startTime = null;
+    this.__shouldHandlePopstateEvents = true;
   }
 
   /**
@@ -106,6 +107,15 @@ export default class Router {
 
   catchall() {
     WindowEnv.navigate(this.__catchallPath)
+  }
+
+  /**
+   * @param {function} fn - Function to execute while popstate listener is disabled
+   */
+  executeWithoutPopstateListener(fn) {
+    this.__shouldHandlePopstateEvents = false;
+    fn();
+    this.__shouldHandlePopstateEvents = true;
   }
 
   /**
@@ -227,7 +237,7 @@ export default class Router {
   }
 
   __onpopstate(e) {
-    if (e.state) {
+    if (e.state && this.__shouldHandlePopstateEvents) {
       this.__dispatch(e.state.path, 'pop');
     }
   }

--- a/test/Router.spec.js
+++ b/test/Router.spec.js
@@ -571,6 +571,41 @@ describe('Router', () => {
         })
     })
 
+    describe('when handling a popstate event', () => {
+      let dispatchStub;
+      let popstateSpy;
+
+      beforeEach(() => {
+        dispatchStub = sinon.stub(router, '__dispatch');
+        popstateSpy = sinon.spy(router, '__onpopstate');
+      });
+
+      it('should not dispatch a route if the popstate listener is disabled', () => {
+        // Wrap popstate emitter to disable the popstate listener
+        router.executeWithoutPopstateListener(() => {
+          // Simulate a popstate event
+          router.__onpopstate({ state: {} });
+        });
+        
+        // Expect that the popstate handler is called
+        sinon.assert.calledOnce(popstateSpy);
+
+        // Expect that the popstate listener does not trigger a dispatch
+        sinon.assert.notCalled(dispatchStub);
+      });
+
+      it('should dispatch a route if the popstate listener is enabled', () => {
+        // Simulate a popstate event w/o disabling popstate listener
+        router.__onpopstate({ state: {} });
+        
+        // Expect that the popstate handler is called
+        sinon.assert.calledOnce(popstateSpy);
+
+        // Expect that the popstate listener does trigger a dispatch
+        sinon.assert.calledOnce(dispatchStub);
+      });
+    });
+
     describe('onRouteStart', () => {
       beforeEach(() => {
         sinon.stub(fns, 'getNow').returns(123)


### PR DESCRIPTION
# Summary:

## Background:

`nuclear-router` listens for `popstate` events. The browser emits these events when the "Back" button is pressed or when the application executes `window.history.back()`. `nuclear-router` handles these events by re-evaluating the URL and executing the corresponding route handler.

The Optimizely application uses URL hashes (`/my-page#dialog`) to represent when a full page dialog is being shown. This allows the user to close the full page dialog by hitting the "Back" button on their browser. However, in order to close a full page dialog in any other scenario (i.e. the user clicks "Submit" or "Cancel"), the application calls `window.history.back()` to close the dialog and remove the hash from the URL (`/my-page#dialog` -> `/my-page`).

When the application performs this navigation, `nuclear-router` re-evaluates the route handler for that page even though removing the URL hash does not change the underlying route being accessed. This can potentially cause unnecessary API calls and initialization work to be executed.

## Implementation:

This PR adds a method to the `Router` interface called `executeWithoutPopstateListener`. It accepts one parameter, `fn`. This method allows the consuming application to run code without the `popstate` listener active. The code to be executed without the `popstate` listener enabled is placed in the argument `fn`.

This will allow the Optimizely application to close dialogs using `window.history.back()` without the router re-evaluating the route for the page underneath the dialog. For example:

```javascript
function closeDialog() {
    router.executeWithoutPopstateListener(() => {
        /**
         * This will not cause the router to re-evaluate since
         * it's wrapped in this function
         */
        window.history.back();
    });
}
```

# Test Plan:

This PR adds a test case to ensure that the popstate listener is deactivated while executing the function passed to `executeWithoutPopstateListener`.