### PR TITLE
[FE-896] Make executeWithoutPopstateListener asynchronous

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -110,12 +110,19 @@ export default class Router {
   }
 
   /**
-   * @param {function} fn - Function to execute while popstate listener is disabled
+   * @param {function} fn - Async function to execute w/o popstate listener
    */
   executeWithoutPopstateListener(fn) {
     this.__shouldHandlePopstateEvents = false;
-    fn();
-    this.__shouldHandlePopstateEvents = true;
+
+    // Execute the function, then re-enable the popstate listener
+    return fn().then((result) => {
+      this.__shouldHandlePopstateEvents = true;
+      return Promise.resolve(result);
+    }, (error) => {
+      this.__shouldHandlePopstateEvents = true;
+      return Promise.reject(error);
+    });
   }
 
   /**

--- a/test/Router.spec.js
+++ b/test/Router.spec.js
@@ -582,16 +582,18 @@ describe('Router', () => {
 
       it('should not dispatch a route if the popstate listener is disabled', () => {
         // Wrap popstate emitter to disable the popstate listener
-        router.executeWithoutPopstateListener(() => {
+        return router.executeWithoutPopstateListener(() => {
           // Simulate a popstate event
           router.__onpopstate({ state: {} });
-        });
-        
-        // Expect that the popstate handler is called
-        sinon.assert.calledOnce(popstateSpy);
+          return Promise.resolve();
+        })
+          .then(() => {
+            // Expect that the popstate handler is called
+            sinon.assert.calledOnce(popstateSpy);
 
-        // Expect that the popstate listener does not trigger a dispatch
-        sinon.assert.notCalled(dispatchStub);
+            // Expect that the popstate listener does not trigger a dispatch
+            sinon.assert.notCalled(dispatchStub);
+          });
       });
 
       it('should dispatch a route if the popstate listener is enabled', () => {


### PR DESCRIPTION
# Summary:

The method `executeWithoutPopstateListener` was introduced in #13 to allow for executing code without the `popstate` event listener firing in `nuclear-router`.

After re-examining the use case for this method, it was discovered that events which emit `popstate` events, such as hitting the "Back" button or calling `window.history.back()`, almost always queue the page navigation to occur asynchronously. Therefore, this PR changes `executeWithoutPopstateListener` to accept an asynchronous function. This PR also now returns the `Promise` chain that is handled in this method.

# Test Plan:

This PR modifies the unit test for this method to use `Promise`s rather than synchronous execution.