### PR TITLE
exploratory (OPP): Update to play nicely with single-spa

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@optimizely/nuclear-router",
-  "version": "1.4.7",
+  "version": "1.4.7-james-single-spa3",
   "description": "NuclearJS Router",
   "main": "dist/main.js",
   "scripts": {
     "build": "rm -rf dist && babel src --out-dir dist --presets=es2015 --plugins=add-module-exports",
     "test": "karma start karma.conf.js",
+    "watch": "babel src --out-dir dist --presets=es2015 --plugins=add-module-exports --watch",
     "watchtest": "karma start karma.conf.js --autoWatch=true --single-run=false",
     "release": "release-it --no-npm.publish"
   },


### PR DESCRIPTION
## Summary

POC PR to update nuclear-router to play nicely with single spa.

This is mainly:

- Ignore popstate when there are 0 routes (Not sure why the unlisten isnt working)
- Allow no redirect when no route matches