### PR TITLE
require initialization and only navigate to catchAll if defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking Changes
+
+- Require explicit initialization via `initialize` before using. (See #17)
+
+### Fixes
+
+- Ensure that `reset` cleans up the `onpopstate` listener. (See #17)
+- Only navigate to the `catchAll` path if one has been provided. (See #17)
+
+
+## [1.4.7] - April 5th, 2019
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/nuclear-router",
-  "version": "1.4.7",
+  "version": "2.0.0",
   "description": "NuclearJS Router",
   "main": "dist/main.js",
   "scripts": {

--- a/src/Router.js
+++ b/src/Router.js
@@ -33,12 +33,19 @@ export default class Router {
       base: '',
     }, opts)
 
-    this.setInitialState();
-
     this.onRouteStart = this.opts.onRouteStart;
-    this.onRouteComplete = this.opts.onRouteComplete
+    this.onRouteComplete = this.opts.onRouteComplete;
+    this.__onpopstate = this.__onpopstate.bind(this);
+  }
 
-    WindowEnv.addEventListener('popstate', this.__onpopstate.bind(this))
+  initialize() {
+    this.setInitialState();
+    WindowEnv.addEventListener('popstate', this.__onpopstate);
+  }
+
+  reset() {
+    this.setInitialState();
+    WindowEnv.removeEventListener('popstate', this.__onpopstate);
   }
 
   setInitialState() {
@@ -100,13 +107,10 @@ export default class Router {
     this.__dispatch(canonicalPath, 'replace')
   }
 
-  reset() {
-    this.setInitialState();
-    WindowEnv.removeEventListener('popstate', this.__onpopstate)
-  }
-
   catchall() {
-    WindowEnv.navigate(this.__catchallPath)
+    if (typeof this.__catchallPath === 'string') {
+      WindowEnv.navigate(this.__catchallPath);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR requires consumers to explicitly call `initialize` before consuming the instance. This allows finer control over when the event listeners are added.

We also enable true cleanup by updating `reset` to remove its `onpopstate` event listener _correctly_.

Finally, only navigate to the catchall route if one is defined (prevents runaway navigation if a URL isn't found).

## Test Plan

Added unit tests here for all new behavior and verified it works by `yarn link`ing in the monolith