### PR TITLE
feat (popstate): Support higher fidelity popstate event handling

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -28,6 +28,7 @@ export default class Context {
   getHistoryArgs() {
     let state = {
       path: this.canonicalPath,
+      nuclearDispatchId: this.dispatchId,
     }
     let url = this.canonicalPath
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -36,6 +36,7 @@ export default class Router {
     this.onRouteStart = this.opts.onRouteStart;
     this.onRouteComplete = this.opts.onRouteComplete;
     this.__onpopstate = this.__onpopstate.bind(this);
+    this.__filterPopstateEvent = this.opts.filterPopstateEvent || (() => true);
   }
 
   initialize() {
@@ -249,7 +250,11 @@ export default class Router {
 
   __onpopstate(e) {
     if (e.state && this.__shouldHandlePopstateEvents) {
-      this.__dispatch(e.state.path, 'pop');
+      // Make sure this popstate event passes the filter fn and wasn't triggered
+      // as a result of the currently in progress dispatch.
+      if (this.__filterPopstateEvent(e) && e.state.nuclearDispatchId !== this.__dispatchId) {
+        this.__dispatch(e.state.path, 'pop');
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR introduces 2 changes to support finer grained control over handling popstate events.

1. Prevents handling a popstate event that has the same dispatchId as the current dispatch.
2. Allows the consumer to pass a filter function to the router instance that can be used to filter certain popstate events.

## Test Plan

Unit tests added to cover both new pieces of logic.