### PR TITLE
feat (Go): Support passing the mode to router.go

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -16,6 +16,10 @@
  * @param {Function} nextFn
  */
 
+ /**
+  * @typedef {"push" | "replace" | "pop"} Mode
+  */
+
 import assign from 'object-assign'
 import Context from './Context'
 import fns from './fns'
@@ -96,9 +100,10 @@ export default class Router {
 
   /**
    * @param {String} canonicalPath
+   * @param {Mode} mode
    */
-  go(canonicalPath) {
-    this.__dispatch(canonicalPath, 'push')
+  go(canonicalPath, mode = 'push') {
+    this.__dispatch(canonicalPath, mode)
   }
 
   /**
@@ -137,7 +142,7 @@ export default class Router {
    *   - Invoking the onRouteStart and onRouteComplete handlers (if specified)
    * @param {String} path
    * @param {String} canonicalPath
-   * @param {String} mode
+   * @param {Mode} mode
    * @param {Object} routeData
    * @param {Router} routeData.route
    * @param {Object} routeData.params
@@ -230,7 +235,7 @@ export default class Router {
 
   /**
    * @param {String} canonicalPath
-   * @param {String} mode One of 'pop', 'push', 'replace'
+   * @param {Mode} mode
    */
   __dispatch(canonicalPath, mode = 'push') {
     this.__dispatchId++;

--- a/test/Router.spec.js
+++ b/test/Router.spec.js
@@ -533,6 +533,34 @@ describe('Router', () => {
       })
     })
 
+    it('should call history.pushState as the default', function() {
+      router.go('/foo')
+
+      return getMacroTaskResolvedPromise().then(() => {
+        sinon.assert.calledOnce(spy1);
+        sinon.assert.calledOnce(HistoryEnv.pushState);
+      })
+    });
+
+    it('should call history.replaceState when the mode `replace` is passed', function() {
+      router.go('/foo', 'replace')
+
+      return getMacroTaskResolvedPromise().then(() => {
+        sinon.assert.calledOnce(spy1);
+        sinon.assert.calledOnce(HistoryEnv.replaceState);
+      })
+    });
+
+    it('should not call history.<push|replace>State when the mode `pop` is passed', function() {
+      router.go('/foo', 'pop')
+
+      return getMacroTaskResolvedPromise().then(() => {
+        sinon.assert.calledOnce(spy1);
+        sinon.assert.notCalled(HistoryEnv.pushState);
+        sinon.assert.notCalled(HistoryEnv.replaceState);
+      })
+    });
+
     it('should properly parse params', () => {
       router.go('/bar/123/baz?account_id=4')
 


### PR DESCRIPTION
## Summary

This PR enables the `mode` parameter for a routing call to be passed to `Router.go`. This is useful for consumers to be able to invoke the router in `pop` mode, which runs the handlers for the current URL without the side effect of updating the history stack.

This is exactly what happens when `popstate` is called, but it can be useful for other callers in a world where the history stack is altered from outside the context of the Router.